### PR TITLE
Insert custom attributes on the element

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,24 @@ Content of `home.twig`:
 {% endblock %}
 ```
 
+#### Add custom attributes to the html element
+
+**WARNING:** you can override ANY attribute including i.e. `href`. Be careful here as it can cause unwanted results.
+
+```twig
+{{ assets({files: [
+    '@public/css/default.css',
+    '@public/css/print.css',
+    'User/user-edit.css'
+    ], attributes: {
+    rel: 'preload',
+    as: 'style',
+    onload: 'this.onload=null;this.rel=\'stylesheet\''
+    }, name: 'layout.css'})
+}}
+```
+
+
 ## Configure a base path
 
 You should inform the browser where to find the web assets with a `base href` in your layout template. 

--- a/src/TwigAssetsEngine.php
+++ b/src/TwigAssetsEngine.php
@@ -116,10 +116,11 @@ final class TwigAssetsEngine
      *
      * @param array<mixed> $assets Assets
      * @param array<mixed> $options Options
+     * @param array<mixed> $attributes Attributes
      *
      * @return string The content
      */
-    public function assets(array $assets, array $options = []): string
+    public function assets(array $assets, array $options = [], array $attributes = []): string
     {
         $assets = $this->prepareAssets($assets);
         $options = (array)array_replace_recursive($this->options, $options);
@@ -135,8 +136,8 @@ final class TwigAssetsEngine
                 $cssFiles[] = $file;
             }
         }
-        $cssContent = $this->css($cssFiles, $options);
-        $jsContent = $this->js($jsFiles, $options);
+        $cssContent = $this->css($cssFiles, $options, $attributes);
+        $jsContent = $this->js($jsFiles, $options, $attributes);
 
         return $cssContent . $jsContent;
     }
@@ -202,10 +203,11 @@ final class TwigAssetsEngine
      *
      * @param array<mixed> $assets Array of asset that would be embed to css
      * @param array<mixed> $options Array of option / setting
+     * @param array<mixed> $customAttributes Array of attributes to override default ones
      *
      * @return string The CSS content
      */
-    public function css(array $assets, array $options): string
+    public function css(array $assets, array $options, array $customAttributes): string
     {
         $contents = [];
         $content = '';
@@ -213,12 +215,15 @@ final class TwigAssetsEngine
         foreach ($assets as $asset) {
             if ($this->isExternalUrl($asset)) {
                 // External url
-                $attributes = $this->createAttributes([
-                    'rel' => 'stylesheet',
-                    'type' => 'text/css',
-                    'href' => $asset,
-                    'media' => 'all',
-                ], $options);
+                $attributes = $this->createAttributes(array_merge(
+                    [
+                        'rel' => 'stylesheet',
+                        'type' => 'text/css',
+                        'href' => $asset,
+                        'media' => 'all',
+                    ],
+                    $customAttributes
+                ), $options);
 
                 $contents[] = $this->element('link', $attributes, '', false);
                 continue;
@@ -244,12 +249,15 @@ final class TwigAssetsEngine
             $urlBasePath = $options['url_base_path'] ?? '';
             $url = $this->publicCache->createCacheBustedUrl($name, $content, $urlBasePath);
 
-            $attributes = $this->createAttributes([
-                'rel' => 'stylesheet',
-                'type' => 'text/css',
-                'href' => $url,
-                'media' => 'all',
-            ], $options);
+            $attributes = $this->createAttributes(array_merge(
+                [
+                    'rel' => 'stylesheet',
+                    'type' => 'text/css',
+                    'href' => $url,
+                    'media' => 'all',
+                ],
+                $customAttributes
+            ), $options);
 
             $contents[] = $this->element('link', $attributes, '', false);
         }
@@ -331,10 +339,11 @@ final class TwigAssetsEngine
      *
      * @param array<mixed> $assets Assets
      * @param array<mixed> $options Options
+     * @param array<mixed> $customAttributes Array of attributes to override default ones
      *
      * @return string The content
      */
-    public function js(array $assets, array $options): string
+    public function js(array $assets, array $options, array $customAttributes): string
     {
         $contents = [];
         $content = '';
@@ -342,7 +351,13 @@ final class TwigAssetsEngine
         foreach ($assets as $asset) {
             if ($this->isExternalUrl($asset)) {
                 // External url
-                $attributes = $this->createAttributes(['src' => $asset], $options);
+                $attributes = $this->createAttributes(
+                    array_merge(
+                        ['src' => $asset],
+                        $customAttributes
+                    ),
+                    $options
+                );
                 $contents[] = $this->element('script', $attributes, '', true);
 
                 continue;
@@ -367,7 +382,13 @@ final class TwigAssetsEngine
 
             $urlBasePath = $options['url_base_path'] ?? '';
             $url = $this->publicCache->createCacheBustedUrl($name, $content, $urlBasePath);
-            $attributes = $this->createAttributes(['src' => $url], $options);
+            $attributes = $this->createAttributes(
+                array_merge(
+                    ['src' => $url],
+                    $customAttributes
+                ),
+                $options
+            );
             $contents[] = $this->element('script', $attributes, '', true);
         }
 

--- a/src/TwigAssetsExtension.php
+++ b/src/TwigAssetsExtension.php
@@ -54,8 +54,12 @@ final class TwigAssetsExtension extends AbstractExtension
         $params = func_get_args();
         $assets = $params[0]['files'];
         unset($params[0]['files']);
+
+        $attributes = $params[0]['attributes'] ?? [];
+        unset($params[0]['attributes']);
+
         $options = $params[0];
 
-        return $this->engine->assets($assets, $options);
+        return $this->engine->assets($assets, $options, $attributes);
     }
 }

--- a/tests/TwigAssetsExtensionTest.php
+++ b/tests/TwigAssetsExtensionTest.php
@@ -108,6 +108,35 @@ class TwigAssetsExtensionTest extends AbstractTest
      *
      * @return void
      */
+    public function testJsWithCustomAttributes()
+    {
+        $file = vfsStream::newFile('public/test.js')->at($this->root)->setContent('alert(3);');
+        $realFileUrl = $file->url();
+        $filename = '@public/test.js';
+
+        $actual = $this->extension->assets(
+            [
+                'files' => [$filename],
+                'attributes' => [
+                    'type' => 'application/javascript'
+                ],
+                'inline' => false
+            ]
+        );
+
+        $dom = new \DOMDocument();
+        $dom->loadHTML($actual);
+        $element = $dom->getElementsByTagName('script')->item(0);
+
+        // new or overwritten attribute
+        $this->assertSame('application/javascript', $element->getAttribute('type'));
+    }
+
+    /**
+     * Test.
+     *
+     * @return void
+     */
     public function testCssDefault()
     {
         $content = 'body {
@@ -127,9 +156,52 @@ class TwigAssetsExtensionTest extends AbstractTest
         $actual2 = $this->extension->assets(['files' => [$filename], 'inline' => false]);
         $this->assertRegExp($this->styleInlineFileRegex, $actual2);
 
-        // update js file, cache must be rebuild
+        // update css file, cache must be rebuild
         file_put_contents($filename, 'alert(4);');
         $actual3 = $this->extension->assets(['files' => [$filename], 'inline' => false]);
         $this->assertRegExp($this->styleInlineFileRegex, $actual3);
+    }
+
+    /**
+     * Test.
+     *
+     * @return void
+     */
+    public function testCssWithCustomAttributes()
+    {
+        $content = 'body {
+            /* background-color: #F4F4F4; */
+            background-color: #f9fafa;
+            /* background-color: #f8f8f8; */
+            /* 60px to make the container go all the way to the bottom of the topbar */
+            padding-top: 60px;
+        }';
+
+        $file = vfsStream::newFile('test.css')->at($this->root)->setContent($content);
+        $filename = $file->url();
+
+        $actual = $this->extension->assets(
+            [
+                'files'  => [$filename],
+                'attributes' => [
+                    'rel' => 'preload',
+                    'as' => 'style',
+                    'onload' => 'this.onload=null;this.rel=\'stylesheet\''
+                ],
+                'inline' => false,
+            ]
+        );
+
+        $dom = new \DOMDocument();
+        $dom->loadHTML($actual);
+        $element = $dom->getElementsByTagName('link')->item(0);
+
+        // new or overwritten attribute
+        $this->assertSame('preload', $element->getAttribute('rel'));
+        $this->assertSame('style', $element->getAttribute('as'));
+        $this->assertSame('this.onload=null;this.rel=\'stylesheet\'', $element->getAttribute('onload'));
+
+        //untouched default attribute
+        $this->assertSame('all', $element->getAttribute('media'));
     }
 }


### PR DESCRIPTION
Hi Odan,
first of all, thanks for all your work on this package. It does the job :-) 

I am currently working on a project with very high focus on the performance. I need to be able to defer loading of uncritical CSS (https://web.dev/defer-non-critical-css/). 

In essence, my desired `assets` function output should look similar to:
```
<link rel="preload" href="../css/components/style.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
```

In order to do so, I've added a possibility to add custom attributes to the final html element. What is important, it is capable to override default attributes specified in the engine.

Default behavior is unchanged, so it is fully compatible with current implementations. 

I've also included tests and readme update.

Example usage:
```
{{ assets({files: [
    '@assets/css/components/one.css',
    '@assets/css/components/two.css'
], attributes: {
    rel: 'preload',
    as: 'style',
    onload: 'this.onload=null;this.rel=\'stylesheet\''
}, name: 'test'}) }}
```

Output:
```
<link rel="preload" type="text/css" href="cache/test.d9dd34444345f823e0a667677cbb5864e9840e0b.css" media="all" as="style" onload="this.onload=null;this.rel='stylesheet'" />
```

Same thing is possible with .js files for any reason.

Cheers!
